### PR TITLE
Fix Linux build and WMI NetworkStream disposal crash

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
 	<PropertyGroup>
 		<!-- Build settings -->
 		<TitanisSigningKeyFile Condition="'$(TitanisSigningKeyFile)'=='' and Exists('$(SolutionDir)\Titanis.snk')">$(SolutionDir)\Titanis.snk</TitanisSigningKeyFile>
+		<LangVersion>12.0</LangVersion>
 		<Nullable>enable</Nullable>
 
 		<ArtifactsPath>$(ArtifactsPath)/lib</ArtifactsPath>

--- a/src/base/Titanis.Winterop.FileInfo/Titanis.Winterop.FileInfo.csproj
+++ b/src/base/Titanis.Winterop.FileInfo/Titanis.Winterop.FileInfo.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>12.0</LangVersion>
 	  <RootNamespace>Titanis.Winterop</RootNamespace>
   </PropertyGroup>
 

--- a/src/base/Titanis.Winterop.Security/Titanis.Winterop.Security.csproj
+++ b/src/base/Titanis.Winterop.Security/Titanis.Winterop.Security.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/build/Titanis.SourceGen/Titanis.SourceGen.csproj
+++ b/src/build/Titanis.SourceGen/Titanis.SourceGen.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>12.0</LangVersion>
 
 		<IsRoslynComponent>true</IsRoslynComponent>
 		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>


### PR DESCRIPTION
## Build System Fixes

- Add LangVersion 12.0 to src/Directory.Build.props to fix C# language version detection for netstandard2.x projects
- Add explicit LangVersion 12.0 to Titanis.SourceGen.csproj (netstandard2.0)
- Add explicit LangVersion 12.0 to Titanis.Winterop.Security.csproj (netstandard2.1)
- Add explicit LangVersion 12.0 to Titanis.Winterop.FileInfo.csproj (netstandard2.1)

Previously, netstandard2.0 and netstandard2.1 projects defaulted to C# 7.3 and 8.0, causing build failures with C# 9.0+ and 12.0 features. This enables building on Linux with .NET SDK 8.0.

## Bug Fix

- Fix NetworkStream disposal race condition in RpcClientChannel.CancelRequest()

Add exception handling to gracefully handle ObjectDisposedException when the NetworkStream is disposed during cleanup before the cancellation callback fires. This prevents crashes after successful WMI command execution.

Fixes: Unhandled ObjectDisposedException crash in WMI tool after successful operations