### PR TITLE
NTLM AV-pair fixes, keyless-session signing fix, LDAP simple bind, KERB-KEY-LIST support, SRVS GetDisks

### DIFF
--- a/src/net/Titanis.Ldap/LdapClient.cs
+++ b/src/net/Titanis.Ldap/LdapClient.cs
@@ -187,6 +187,12 @@ namespace Titanis.Ldap
 			return ldap;
 		}
 
+		// RFC 4511 simple bind
+		public async Task BindSimple(string distinguishedName, string password, CancellationToken cancellationToken)
+		{
+			await this._channel.BindSimple(distinguishedName, password, cancellationToken).ConfigureAwait(false);
+		}
+
 		private static readonly Regex rgxLdapServiceName = LdapServiceRegex();
 		[GeneratedRegex(@"^(?<forest>[^:]*):(?<computer>[^@]*)@(?<domain>.*)$")]
 		private static partial Regex LdapServiceRegex();

--- a/src/net/Titanis.Ldap/LdapClientChannel.cs
+++ b/src/net/Titanis.Ldap/LdapClientChannel.cs
@@ -18,6 +18,22 @@ namespace Titanis.Ldap
 		private AuthClientContext? _authContext;
 		protected override AuthContext? AuthContext => this._authContext;
 
+		// RFC 4511 simple bind support
+		internal async Task<LdapResponse> BindSimple(string? distinguishedName, string? password, CancellationToken cancellationToken)
+		{
+			var resp = await this.SendRequest(new LDAPMessage_ProtocolOp()
+			{
+				BindRequest = new BindRequest_Tagged0(3, Encoding.UTF8.GetBytes(distinguishedName ?? string.Empty), new AuthenticationChoice()
+				{
+					Simple = Encoding.UTF8.GetBytes(password ?? string.Empty)
+				})
+			}, cancellationToken).ConfigureAwait(false);
+			var resultCode = resp.message.protocolOp.BindResponse.resultCode;
+			if (resultCode != LDAPResult_ResultCode.Success)
+				throw new LdapException((LdapResultCode)resultCode, Encoding.UTF8.GetString(resp.message.protocolOp.BindResponse.diagnosticMessage));
+			return resp;
+		}
+
 		internal async Task<LdapResponse> Bind(AuthClientContext authContext, CancellationToken cancellationToken)
 		{
 			var resp = await this.SendRequest(new LDAPMessage_ProtocolOp()

--- a/src/net/Titanis.Smb2/Smb2Session.cs
+++ b/src/net/Titanis.Smb2/Smb2Session.cs
@@ -44,6 +44,10 @@ namespace Titanis.Smb2
 			this.MustEncryptData = mustEncryptData;
 			this._preauthIntegrityValue = preauthIntegrityValue;
 
+			// Anonymous/guest sessions have no session key and cannot sign [MS-SMB2 §3.2.5.2]
+			bool canSign = authContext.HasSessionKey;
+			this._canSign = canSign;
+
 			if (authContext.HasSessionKey)
 			{
 				var authSessionKey = authContext.GetSessionKey();
@@ -110,7 +114,7 @@ namespace Titanis.Smb2
 						Sp800_108.KdfCtr(decLabel, decContext, cipherKeySize, new HMACSHA256(kdk)),
 						signingAlgo,
 						cipher,
-						this.SigningRequired && !mustEncryptData
+						this.SigningRequired && !mustEncryptData && canSign
 						);
 
 					// App key
@@ -125,7 +129,7 @@ namespace Titanis.Smb2
 				}
 				else
 				{
-					this.CryptInfo = new Smb2SessionCryptInfo(this.SigningRequired);
+					this.CryptInfo = new Smb2SessionCryptInfo(this.SigningRequired && canSign);
 					this._sessionAppKey = smb2SessionBaseKey;
 				}
 			}
@@ -135,8 +139,11 @@ namespace Titanis.Smb2
 			this.primaryChannelBinding = new Smb2ChannelBindingInfo(0, conn, signingKey, validateNegotiateInfo);
 		}
 
-		private byte[] DeriveSigningKey(Smb2Dialect dialect, byte[] preauthIntegrityValue, bool binding)
+		private byte[]? DeriveSigningKey(Smb2Dialect dialect, byte[] preauthIntegrityValue, bool binding)
 		{
+			if (this._sessionBaseKey is null)
+				return null;
+
 			byte[] signingKey;
 			if (dialect >= Smb2Dialect.Smb3_0)
 			{
@@ -268,12 +275,13 @@ namespace Titanis.Smb2
 		}
 
 		private bool _firstPdu = true;
+		private readonly bool _canSign;
 		internal Task<Smb2Pdu> SendSyncPduAsync(Pdus.Smb2Pdu req, bool encrypt, CancellationToken cancellationToken)
 		{
-			if (this._firstPdu || req.Command == Smb2Command.TreeConnect)
+			if ((this._firstPdu || req.Command == Smb2Command.TreeConnect)
+				&& !encrypt && this._canSign)
 			{
-				if (!encrypt)
-					req.pduhdr.flags |= Smb2PduFlags.Signed;
+				req.pduhdr.flags |= Smb2PduFlags.Signed;
 				this._firstPdu = false;
 			}
 

--- a/src/net/msrpc/Titanis.Msrpc.Mssrvs/ServerServiceClient.cs
+++ b/src/net/msrpc/Titanis.Msrpc.Mssrvs/ServerServiceClient.cs
@@ -449,6 +449,48 @@ namespace Titanis.Msrpc.Mswkst
 		public Task<IList<ShareInfo>> GetStickyShares(string serverName, ShareInfoLevel level, int bufferSize, CancellationToken cancellationToken)
 			=> EnumShares(serverName, level, bufferSize, this._proxy.NetrShareEnumSticky, cancellationToken);
 
+		// disk enumeration (NetrServerDiskEnum, level 0)
+		public async Task<IList<string>> GetDisks(string serverName, int bufferSize, CancellationToken cancellationToken)
+		{
+			var disks = new List<string>();
+			RpcPointer<uint> pTotal = new RpcPointer<uint>();
+			RpcPointer<uint> pResumeHandle = new RpcPointer<uint>();
+
+			Win32ErrorCode res;
+			do
+			{
+				var pContainer = new RpcPointer<DISK_ENUM_CONTAINER>(new DISK_ENUM_CONTAINER());
+				res = (Win32ErrorCode)await this._proxy.NetrServerDiskEnum(
+					serverName,
+					0,
+					pContainer,
+					(uint)bufferSize,
+					pTotal,
+					pResumeHandle,
+					cancellationToken
+					).ConfigureAwait(false);
+
+				var buffer = pContainer.value.Buffer?.value;
+				if (buffer.HasValue)
+				{
+					var seg = buffer.Value;
+					for (int i = 0; i < pContainer.value.EntriesRead && i < seg.Count; i++)
+					{
+						var dseg = seg.Array![i].Disk;
+						string name = new string(dseg.Array!, dseg.Offset, dseg.Count).TrimEnd('\0');
+						if (name.Length > 0)
+							disks.Add(name);
+					}
+				}
+			}
+			while (res == Win32ErrorCode.ERROR_MORE_DATA);
+
+			if (res != Win32ErrorCode.ERROR_SUCCESS)
+				res.CheckAndThrow();
+
+			return disks;
+		}
+
 		public const int DefaultReturnBufferSize = -1;
 		private static async Task<IList<ShareInfo>> EnumShares(
 			string? serverName,

--- a/src/security/Titanis.Security.Kerberos/KerberosClient.cs
+++ b/src/security/Titanis.Security.Kerberos/KerberosClient.cs
@@ -735,6 +735,16 @@ namespace Titanis.Security.Kerberos
 			TicketInfo ticketInfo = new TicketInfo(GetNextTicketSeqnbr(), rep.ticket, this.CreateSessionKeyFor(encPart.key), encPart, rep.cname.name_string[0].Value, rep.crealm.Value, context.Tgt?.AsrepKey, ticketKey);
 			ticketInfo.Comment = context.ticketParameters?.TicketComment;
 
+			// surface KERB-KEY-LIST-REP ([MS-KILE] § 2.2.12) to callers
+			var atlasKeyListRep = encPart.padata?.FirstOrDefault(r => r.padata_type == (int)PadataType.KerbKeyListRep);
+			if (atlasKeyListRep is not null)
+			{
+				var atlasKeys = Asn1DerDecoder.DecodeTlv<Asn1SequenceOf<EncryptionKey>>(atlasKeyListRep.padata_value);
+				ticketInfo.KeyListKeys = atlasKeys.Values
+					.Select(k => ((int)k.keytype, key: k.keyvalue))
+					.ToArray();
+			}
+
 			this._callback?.OnReceivedTicket(ticketParams.CorrelationId, new KdcRepInfo(context, rep, encPart, null, ticketInfo.SessionKey));
 
 			return ticketInfo;
@@ -1037,7 +1047,9 @@ namespace Titanis.Security.Kerberos
 				padatas.Add(Structs.PAData_FastReq(padata_fastreq));
 			}
 
-			// padatas.Add(Structs.PAData_KerbKeyListReq([EType.Rc4Hmac]));
+			// emit KERB-KEY-LIST-REQ when requested ([MS-KILE] § 2.2.11)
+			if (ticketParameters.KeyListEtypes is not null)
+				padatas.Add(Structs.PAData_KerbKeyListReq(ticketParameters.KeyListEtypes));
 
 
 
@@ -1659,7 +1671,8 @@ namespace Titanis.Security.Kerberos
 			DateTime? renewTill,
 			LogonInfo? logonInfo,
 			UpnDnsInfo? upnDnsInfo,
-			SessionKey? kdcKey
+			SessionKey? kdcKey,
+			uint? encPartKvno = null
 			)
 		{
 			byte[]? ticketChecksum;
@@ -1720,6 +1733,10 @@ namespace Titanis.Security.Kerberos
 					serverKey,
 					[adelem]
 					);
+
+				// allow setting the ticket enc-part kvno (e.g. RODC krbtgt number)
+				if (encPartKvno.HasValue)
+					ticket.ticket.enc_part.kvno = encPartKvno.Value;
 
 				return ticket;
 			}

--- a/src/security/Titanis.Security.Kerberos/TicketInfo.cs
+++ b/src/security/Titanis.Security.Kerberos/TicketInfo.cs
@@ -195,6 +195,9 @@ namespace Titanis.Security.Kerberos
 
 		public string? Comment { get; set; }
 
+		// keys returned via KERB-KEY-LIST-REP ([MS-KILE] § 2.2.12), if any
+		public (int EType, byte[] Key)[]? KeyListKeys { get; internal set; }
+
 		[DisplayName("Client name")]
 		public string? ClientName { get; }
 

--- a/src/security/Titanis.Security.Kerberos/TicketParameters.cs
+++ b/src/security/Titanis.Security.Kerberos/TicketParameters.cs
@@ -22,6 +22,9 @@ namespace Titanis.Security.Kerberos
 		public bool IndicatesS4User => this.S4UserName is not null || this.S4UserCertificate is not null;
 		public SecurityPrincipalName? S4ProxyService { get; set; }
 
+		// KERB-KEY-LIST-REQ support ([MS-KILE] § 2.2.11)
+		public EType[]? KeyListEtypes { get; set; }
+
 		private TicketInfo? _additionalTicket;
 		public TicketInfo? AdditionalTicket
 		{

--- a/src/security/Titanis.Security.Ntlm/NtlmReader.cs
+++ b/src/security/Titanis.Security.Ntlm/NtlmReader.cs
@@ -140,25 +140,28 @@ namespace Titanis.Security.Ntlm
 						eol = true;
 						break;
 					case AvId.NbComputerName:
-						av.NbComputerName = reader.ReadStringUni(avh.avLen);
+						// Preserve empty-valued pairs (e.g. Samba sends MsvAvDnsDomainName with len 0);
+						// they must be echoed back or servers such as Samba reject the session.
+						av.NbComputerName = reader.ReadStringUni(avh.avLen) ?? string.Empty;
 						break;
 					case AvId.NbDomainName:
-						av.NbDomainName = reader.ReadStringUni(avh.avLen);
+						av.NbDomainName = reader.ReadStringUni(avh.avLen) ?? string.Empty;
 						break;
 					case AvId.DnsComputerName:
-						av.DnsComputerName = reader.ReadStringUni(avh.avLen);
+						av.DnsComputerName = reader.ReadStringUni(avh.avLen) ?? string.Empty;
 						break;
 					case AvId.DnsDomainName:
-						av.DnsDomainName = reader.ReadStringUni(avh.avLen);
+						av.DnsDomainName = reader.ReadStringUni(avh.avLen) ?? string.Empty;
 						break;
 					case AvId.DnsTreeName:
-						av.DnsTreeName = reader.ReadStringUni(avh.avLen);
+						av.DnsTreeName = reader.ReadStringUni(avh.avLen) ?? string.Empty;
 						break;
 					case AvId.Flags:
 						av.flags = (NtlmAuthFlags)reader.ReadInt32LE();
 						break;
 					case AvId.Timestamp:
-						av.timestamp = new DateTime(reader.ReadInt64LE());
+						// FILETIME is relative to 1601-01-01 UTC
+						av.timestamp = DateTime.FromFileTimeUtc(reader.ReadInt64LE());
 						break;
 					case AvId.SingleHost:
 						av.singleHost = reader.ReadSingleHostData(avh.avLen);

--- a/src/security/Titanis.Security.Ntlm/NtlmWriter.cs
+++ b/src/security/Titanis.Security.Ntlm/NtlmWriter.cs
@@ -53,7 +53,7 @@ namespace Titanis.Security.Ntlm
 		{
 			writer.WriteUInt16LE((ushort)avid);
 			writer.WriteUInt16LE(8);
-			writer.WriteInt64LE(timestamp.Ticks);
+			writer.WriteInt64LE(timestamp.ToFileTimeUtc());
 		}
 
 		internal static void WriteAv(this ByteWriter writer, AvId avid, NtlmAuthFlags flags)


### PR DESCRIPTION
## Summary

This PR contains five changes developed while building an external client on top of the Titanis libraries. Each is independent; happy to split into separate PRs if preferred.

### 1. fix(ntlm): preserve empty AV pairs and use FILETIME for MsvAvTimestamp
`ReadAvInfo` mapped zero-length AV string values to `null`, so `WriteAvInfo` dropped those pairs when echoing TargetInfo in the NTLMv2 response. Samba sends e.g. `MsvAvDnsDomainName` with length 0 and requires every challenge AV pair to be echoed — dropping it fails session setup with `STATUS_INVALID_PARAMETER` (`ntlmssp_server_preauth: "AvId 0x4 missing"`). Empty values now decode as `string.Empty` so the pairs round-trip.

Also decodes `MsvAvTimestamp` with `DateTime.FromFileTimeUtc` (epoch 1601) and encodes via `ToFileTimeUtc`, so the value round-trips as a correct FILETIME instead of .NET ticks.

### 2. fix(smb2): do not sign PDUs on sessions without a session key
Anonymous/guest sessions produce no session key, but session setup still marked CryptInfo signing-capable and force-set the Signed flag on the first PDU/TreeConnect. This crashed at `DeriveSigningKey` (`HMACSHA256(null)`) and later inside GMAC signing. Gated on `authContext.HasSessionKey` per [MS-SMB2] §3.2.5.2 (anonymous/guest sessions do not sign).

### 3. feat(ldap): RFC 4511 simple bind
The ASN.1 layer already models `AuthenticationChoice.Simple`, but only SASL binds were exposed. Adds `BindSimple` to `LdapClientChannel`/`LdapClient` for servers that only support simple binds (e.g. OpenLDAP). Verified against ldap.forumsys.com.

### 4. feat(kerberos): KERB-KEY-LIST-REQ/REP + optional enc-part kvno on ForgeTicket
- `TicketParameters.KeyListEtypes` emits a KERB-KEY-LIST-REQ [161] padata in TGS-REQ ([MS-KILE] §2.2.11).
- `ProcessTgsRep` decodes KERB-KEY-LIST-REP [162] from the reply's encrypted pa-data and surfaces it as `TicketInfo.KeyListKeys` ([MS-KILE] §2.2.12).
- `ForgeTicket` gains optional `encPartKvno`, written into the ticket enc-part — required to address RODC krbtgt keys (`kvno = rodcNo << 16`) for Key List requests against RODCs.

Verified end-to-end against a Windows Server DC: forged RODC TGT + KEY-LIST-REQ reaches the KDC and returns structured KDC errors (S_PRINCIPAL_UNKNOWN for an unknown RODC number, PREAUTH_FAILED path for bad credentials).

### 5. feat(srvs): GetDisks wrapper
Adds a level-0 `NetrServerDiskEnum` helper following the same resume-loop convention as `GetSessions`/`EnumShares`.

## Testing

* Full builds of all five affected projects (Security.Ntlm, Smb2, Ldap, Security.Kerberos, Mssrvs) — 0 errors.
* Behavioral testing against Samba 4.15 (member server), a Windows Server DC, and OpenLDAP:
  * NTLM auth against Samba previously failed with `STATUS_INVALID_PARAMETER`; succeeds after change 1.
  * Anonymous SMB session setup previously crashed; completes after change 2.
  * LDAP simple bind + queries verified against OpenLDAP.