### PR TITLE
Handle NTLMv1 authenticate messages

### DIFF
--- a/src/security/Titanis.Security.Ntlm/NtlmStructs.cs
+++ b/src/security/Titanis.Security.Ntlm/NtlmStructs.cs
@@ -158,10 +158,17 @@ namespace Titanis.Security.Ntlm
 			out ReadOnlySpan<byte> targetInfoBytes)
 		{
 			var msg = Parse(bytes);
-			targetInfoBytes = bytes.Slice(
-				msg.hdr.ntChallengeResponse.offset + 16 + NtlmClientChallenge.StructSize,
-				msg.hdr.ntChallengeResponse.len - 16 - NtlmClientChallenge.StructSize - 4 /* Z4 */
-				);
+			if (msg.IsNtlmv2)
+			{
+				targetInfoBytes = bytes.Slice(
+					msg.hdr.ntChallengeResponse.offset + 16 + NtlmClientChallenge.StructSize,
+					msg.hdr.ntChallengeResponse.len - 16 - NtlmClientChallenge.StructSize - 4 /* Z4 */
+					);
+			}
+			else
+			{
+				targetInfoBytes = ReadOnlySpan<byte>.Empty;
+			}
 			return msg;
 		}
 		public static NtlmAuthenticate Parse(

--- a/test/security/Titanis.Security.Ntlm.Test/NtlmTests.cs
+++ b/test/security/Titanis.Security.Ntlm.Test/NtlmTests.cs
@@ -12,6 +12,24 @@ namespace Titanis.Security.Ntlm.Test
 	[TestClass]
 	public class NtlmTests
 	{
+		[TestMethod]
+		public void TestServerAcceptsNtlmv1Authentication()
+		{
+			NtlmAuthStore authStore = new NtlmAuthStore(new Dictionary<string, NtlmAuthRecord>
+			{
+				{ TestInputValues.UserName, new NtlmAuthRecord(Ntlm.LmowfV1(TestInputValues.Password), Ntlm.NtowfV1(TestInputValues.Password)) }
+			});
+			NtlmServerContext context = new NtlmServerContext(authStore)
+			{
+				ServerName = TestInputValues.ServerName,
+				DomainName = TestInputValues.Domain
+			};
+			context.SetAuthState(TestValues.ChallengeFlagsV1, TestInputValues.ServerChallenge, TestInputValues.Time);
+
+			context.Accept(TestValues.AuthMessage_V1);
+
+			Assert.IsTrue(context.HasSessionKey);
+		}
 
 		// [MS-NLMP] § 4.2.2.1.1 - LMOWFv1()
 		[TestMethod("[MS-NLMP] § 4.2.2.1.1 - LMOWFv1()")]


### PR DESCRIPTION
Hey Hey, Was looking at the Titanis sourcecode while doing some IoC testing and spotted that it was doing unconditional splicing to extract target-info bytes, which I believe to be an issue as that is only valid behaviour for NTLMv2.

The PR adds a gate to confirm its an NTLMv2 message before splicing 